### PR TITLE
Depend on electron-updater v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "electron-log": "^1.3.0",
-    "electron-updater": "^3.1.2"
+    "electron-updater": "^4.0.6"
   },
   "build": {
     "appId": "com.github.iffy.electronupdaterexample",


### PR DESCRIPTION
Otherwise running `yarn build -p always` errors out with At least electron-updater 4.0.0 is recommended by current electron-builder version. Please set electron-updater version to "^4.0.0"